### PR TITLE
Add AllDay and PackNFT contracts

### DIFF
--- a/src/cadence/mainnet/getNFTIDs.cdc
+++ b/src/cadence/mainnet/getNFTIDs.cdc
@@ -36,6 +36,8 @@ import OneFootballCollectible from 0x6831760534292098
 import TheFabricantMysteryBox_FF1 from 0xa0cbe021821c0965
 import DieselNFT from 0x497153c597783bc3
 import MiamiNFT from 0x429a19abea586a3e
+import AllDay from 0xe4cf4bdc1751c65d
+import PackNFT from 0xe4cf4bdc1751c65d
 
 pub fun main(ownerAddress: Address): {String: [UInt64]} {
     let owner = getAccount(ownerAddress)
@@ -202,5 +204,15 @@ pub fun main(ownerAddress: Address): {String: [UInt64]} {
     .borrow<&{MiamiNFT.MiamiCollectionPublic}>() {
         ids["MiamiNFT"] = col.getIDs()
     }
+
+    if let col = owner.getCapability(AllDay.CollectionPublicPath)
+        .borrow<&{AllDay.MomentNFTCollectionPublic}>() {
+            ids["AllDay"] = col.getIDs()
+    }
+    if let col = owner.getCapability(PackNFT.CollectionPublicPath)
+        .borrow<&{NonFungibleToken.CollectionPublic}>() {
+            ids["PackNFT"] = col.getIDs()
+    }
+
     return ids
 }

--- a/src/cadence/mainnet/getNFTs.cdc
+++ b/src/cadence/mainnet/getNFTs.cdc
@@ -167,7 +167,7 @@ pub fun main(ownerAddress: Address, ids: {String:[UInt64]}): [NFTData?] {
                 case "DieselNFT": d = getDieselNFT(owner: owner, id: id)
                 case "MiamiNFT": d = getMiamiNFT(owner: owner, id: id)
                 case "AllDay": d = getAllDay(owner: owner, id: id)
-                case "PackNFT": d = getPackNFT(owner: owner, id: id)
+                case "PackNFT": d = getAllDayPackNFT(owner: owner, id: id)
                 default:
                     panic("adapter for NFT not found: ".concat(key))
             }
@@ -1524,7 +1524,7 @@ pub fun getAllDay(owner: PublicAccount, id: UInt64): NFTData? {
 }
 
 // https://flow-view-source.com/mainnet/account/0xe4cf4bdc1751c65d/contract/PackNFT
-pub fun getPackNFT(owner: PublicAccount, id: UInt64): NFTData? {
+pub fun getAllDayPackNFT(owner: PublicAccount, id: UInt64): NFTData? {
     let contract = NFTContract(
         name: "PackNFT",
         address: 0xe4cf4bdc1751c65d,

--- a/src/cadence/mainnet/getNFTs.cdc
+++ b/src/cadence/mainnet/getNFTs.cdc
@@ -36,6 +36,8 @@ import OneFootballCollectible from 0x6831760534292098
 import TheFabricantMysteryBox_FF1 from 0xa0cbe021821c0965
 import DieselNFT from 0x497153c597783bc3
 import MiamiNFT from 0x429a19abea586a3e
+import AllDay from 0xe4cf4bdc1751c65d
+import PackNFT from 0xe4cf4bdc1751c65d
 
 pub struct NFTCollection {
     pub let owner: Address
@@ -164,6 +166,8 @@ pub fun main(ownerAddress: Address, ids: {String:[UInt64]}): [NFTData?] {
                 case "TheFabricantMysteryBox_FF1": d = getTheFabricantMysteryBox_FF1(owner: owner, id: id)
                 case "DieselNFT": d = getDieselNFT(owner: owner, id: id)
                 case "MiamiNFT": d = getMiamiNFT(owner: owner, id: id)
+                case "AllDay": d = getAllDay(owner: owner, id: id)
+                case "PackNFT": d = getPackNFT(owner: owner, id: id)
                 default:
                     panic("adapter for NFT not found: ".concat(key))
             }
@@ -1485,5 +1489,67 @@ pub fun getMiamiNFT(owner: PublicAccount, id: UInt64): NFTData? {
             "creator": miamiData.creator,
             "season": miamiData.season
         },
+    )
+}
+
+// https://flow-view-source.com/mainnet/account/0xe4cf4bdc1751c65d/contract/AllDay
+pub fun getAllDay(owner: PublicAccount, id: UInt64): NFTData? {
+    let contract = NFTContract(
+        name: "AllDay",
+        address: 0xe4cf4bdc1751c65d,
+        storage_path: "AllDay.CollectionStoragePath",
+        public_path: "AllDay.CollectionPublicPath",
+        public_collection_name: "AllDay.MomentNFTCollectionPublic",
+        external_domain: "https://nflallday.com/"
+    )
+
+    let col = owner.getCapability(AllDay.CollectionPublicPath)
+        .borrow<&{AllDay.MomentNFTCollectionPublic}>()
+    if col == nil { return nil }
+
+    let nft = col!.borrowMomentNFT(id: id)
+    if nft == nil { return nil }
+
+    return NFTData(
+        contract: contract,
+        id: nft!.id,
+        uuid: nil,
+        title: "Moment".concat(nft!.id.toString()).concat("-Edition").concat(nft!.editionID.toString()).concat("-SerialNumber").concat(nft!.serialNumber.toString()),
+        description: nil,
+        external_domain_view_url: nil,
+        token_uri: nil,
+        media: [],
+        metadata: {},
+    )
+}
+
+// https://flow-view-source.com/mainnet/account/0xe4cf4bdc1751c65d/contract/PackNFT
+pub fun getPackNFT(owner: PublicAccount, id: UInt64): NFTData? {
+    let contract = NFTContract(
+        name: "PackNFT",
+        address: 0xe4cf4bdc1751c65d,
+        storage_path: "PackNFT.CollectionStoragePath",
+        public_path: "PackNFT.CollectionPublicPath",
+        public_collection_name: "NonFungibleToken.CollectionPublic",
+        external_domain: "https://nflallday.com/"
+    )
+
+    let col = owner.getCapability(PackNFT.CollectionPublicPath)
+        .borrow<&{NonFungibleToken.CollectionPublic}>()
+    if col == nil { return nil }
+
+    let nft = col!.borrowNFT(id: id)
+    if nft == nil { return nil }
+
+    return NFTData(
+        contract: contract,
+        id: nft!.id,
+        uuid: nil,
+        title: nil,
+        description: nil,
+        external_domain_view_url: nil,
+        token_uri: nil,
+        media: [],
+        metadata: {},
     )
 }

--- a/src/cadence/mainnet/testGetNFTs.sh
+++ b/src/cadence/mainnet/testGetNFTs.sh
@@ -160,6 +160,17 @@ case $CONTRACT in
   echo "MiamiNFT"
     flow scripts execute getNFTs.cdc --args-json '[{ "type": "Address", "value": "0xe1d5954d03ccb02d" }, { "type": "Dictionary", "value": [{ "key": { "type": "String", "value": "MiamiNFT" }, "value": { "type": "Array", "value": [{ "type": "UInt64", "value": "1" }] } }] }]' --network mainnet
     ;;
+    
+  AllDay)
+    echo "AllDay"
+    flow scripts execute getNFTs.cdc --args-json '[{ "type": "Address", "value": "0xe4cf4bdc1751c65d" }, { "type": "Dictionary", "value": [{ "key": { "type": "String", "value": "AllDay" }, "value": { "type": "Array", "value": [{ "type": "UInt64", "value": "50" }] } }] }]' --network mainnet
+    ;;
+  
+  PackNFT)
+    echo "PackNFT"
+    flow scripts execute getNFTs.cdc --args-json '[{ "type": "Address", "value": "0xe4cf4bdc1751c65d" }, { "type": "Dictionary", "value": [{ "key": { "type": "String", "value": "PackNFT" }, "value": { "type": "Array", "value": [{ "type": "UInt64", "value": "1" }] } }] }]' --network mainnet
+    ;;
+
   *)
     echo "Unknown contract"
     ;;

--- a/src/cadence/mainnet/testGetNFTs.sh
+++ b/src/cadence/mainnet/testGetNFTs.sh
@@ -167,7 +167,7 @@ case $CONTRACT in
     ;;
   
   PackNFT)
-    echo "PackNFT"
+    echo "AllDayPackNFT"
     flow scripts execute getNFTs.cdc --args-json '[{ "type": "Address", "value": "0xe4cf4bdc1751c65d" }, { "type": "Dictionary", "value": [{ "key": { "type": "String", "value": "PackNFT" }, "value": { "type": "Array", "value": [{ "type": "UInt64", "value": "1" }] } }] }]' --network mainnet
     ;;
 

--- a/src/cadence/testnet/getNFTIDs.cdc
+++ b/src/cadence/testnet/getNFTIDs.cdc
@@ -32,6 +32,8 @@ import OneFootballCollectible from 0x01984fb4ca279d9a
 import TheFabricantMysteryBox_FF1 from 0x716db717f9240d8a
 import DieselNFT from 0x716db717f9240d8a
 import MiamiNFT from 0x716db717f9240d8a
+import AllDay from 0x4dfd62c88d1b6462
+import PackNFT from 0x4dfd62c88d1b6462
 
 pub fun main(ownerAddress: Address): {String: [UInt64]} {
     let owner = getAccount(ownerAddress)
@@ -181,5 +183,14 @@ pub fun main(ownerAddress: Address): {String: [UInt64]} {
         ids["MiamiNFT"] = col.getIDs()
     }
     
+    if let col = owner.getCapability(AllDay.CollectionPublicPath)
+        .borrow<&{AllDay.MomentNFTCollectionPublic}>() {
+            ids["AllDay"] = col.getIDs()
+    } 
+    if let col = owner.getCapability(PackNFT.CollectionPublicPath)
+        .borrow<&{NonFungibleToken.CollectionPublic}>() {
+            ids["PackNFT"] = col.getIDs()
+    }
+
     return ids
 }

--- a/src/cadence/testnet/getNFTs.cdc
+++ b/src/cadence/testnet/getNFTs.cdc
@@ -32,6 +32,8 @@ import OneFootballCollectible from 0x01984fb4ca279d9a
 import TheFabricantMysteryBox_FF1 from 0x716db717f9240d8a
 import DieselNFT from 0x716db717f9240d8a
 import MiamiNFT from 0x716db717f9240d8a
+import AllDay from 0x4dfd62c88d1b6462
+import PackNFT from 0x4dfd62c88d1b6462
 
 pub struct NFTCollection {
     pub let owner: Address
@@ -152,6 +154,8 @@ pub fun main(ownerAddress: Address, ids: {String:[UInt64]}): [NFTData?] {
                 case "TheFabricantMysteryBox_FF1": d = getTheFabricantMysteryBox_FF1(owner: owner, id: id)
                 case "DieselNFT": d = getDieselNFT(owner: owner, id: id)
                 case "MiamiNFT": d = getMiamiNFT(owner: owner, id: id)
+                case "AllDay": d = getAllDay(owner: owner, id: id)
+                case "PackNFT": d = getPackNFT(owner: owner, id: id)
                 default:
                     panic("adapter for NFT not found: ".concat(key))
             }
@@ -1204,6 +1208,7 @@ pub fun getOneFootballCollectible(owner: PublicAccount, id: UInt64): NFTData? {
     return nil
 }
 
+
 // https://flow-view-source.com/testnet/account/0x716db717f9240d8a/contract/TheFabricantMysteryBox_FF1
 pub fun getTheFabricantMysteryBox_FF1(owner: PublicAccount, id: UInt64): NFTData? {
     let contract = NFTContract(
@@ -1303,5 +1308,67 @@ pub fun getMiamiNFT(owner: PublicAccount, id: UInt64): NFTData? {
             "creator": miamiData.creator,
             "season": miamiData.season
         },
+    )
+}
+
+// https://flow-view-source.com/testnet/account/0x4dfd62c88d1b6462/contract/AllDay
+pub fun getAllDay(owner: PublicAccount, id: UInt64): NFTData? {
+    let contract = NFTContract(
+        name: "AllDay",
+        address: 0x4dfd62c88d1b6462,
+        storage_path: "AllDay.CollectionStoragePath",
+        public_path: "AllDay.CollectionPublicPath",
+        public_collection_name: "AllDay.MomentNFTCollectionPublic",
+        external_domain: "https://nflallday.com/"
+    )
+
+    let col = owner.getCapability(AllDay.CollectionPublicPath)
+        .borrow<&{AllDay.MomentNFTCollectionPublic}>()
+    if col == nil { return nil }
+
+    let nft = col!.borrowMomentNFT(id: id)
+    if nft == nil { return nil }
+
+    return NFTData(
+        contract: contract,
+        id: nft!.id,
+        uuid: nil,
+        title: "Moment".concat(nft!.id.toString()).concat("-Edition").concat(nft!.editionID.toString()).concat("-SerialNumber").concat(nft!.serialNumber.toString()),
+        description: nil,
+        external_domain_view_url: nil,
+        token_uri: nil,
+        media: [],
+        metadata: {},
+    )
+}
+
+// https://flow-view-source.com/testnet/account/0x4dfd62c88d1b6462/contract/PackNFT
+pub fun getPackNFT(owner: PublicAccount, id: UInt64): NFTData? {
+    let contract = NFTContract(
+        name: "PackNFT",
+        address: 0x4dfd62c88d1b6462,
+        storage_path: "PackNFT.CollectionStoragePath",
+        public_path: "PackNFT.CollectionPublicPath",
+        public_collection_name: "NonFungibleToken.CollectionPublic",
+        external_domain: "https://nflallday.com/"
+    )
+
+    let col = owner.getCapability(PackNFT.CollectionPublicPath)
+        .borrow<&{NonFungibleToken.CollectionPublic}>()
+    if col == nil { return nil }
+
+    let nft = col!.borrowNFT(id: id)
+    if nft == nil { return nil }
+
+    return NFTData(
+        contract: contract,
+        id: nft!.id,
+        uuid: nil,
+        title: nil,
+        description: nil,
+        external_domain_view_url: nil,
+        token_uri: nil,
+        media: [],
+        metadata: {},
     )
 }

--- a/src/cadence/testnet/getNFTs.cdc
+++ b/src/cadence/testnet/getNFTs.cdc
@@ -155,7 +155,7 @@ pub fun main(ownerAddress: Address, ids: {String:[UInt64]}): [NFTData?] {
                 case "DieselNFT": d = getDieselNFT(owner: owner, id: id)
                 case "MiamiNFT": d = getMiamiNFT(owner: owner, id: id)
                 case "AllDay": d = getAllDay(owner: owner, id: id)
-                case "PackNFT": d = getPackNFT(owner: owner, id: id)
+                case "PackNFT": d = getAllDayPackNFT(owner: owner, id: id)
                 default:
                     panic("adapter for NFT not found: ".concat(key))
             }
@@ -1343,7 +1343,7 @@ pub fun getAllDay(owner: PublicAccount, id: UInt64): NFTData? {
 }
 
 // https://flow-view-source.com/testnet/account/0x4dfd62c88d1b6462/contract/PackNFT
-pub fun getPackNFT(owner: PublicAccount, id: UInt64): NFTData? {
+pub fun getAllDayPackNFT(owner: PublicAccount, id: UInt64): NFTData? {
     let contract = NFTContract(
         name: "PackNFT",
         address: 0x4dfd62c88d1b6462,


### PR DESCRIPTION
This PR adds support for the Dapper Labs project NFL ALLDAY. This adds the following contracts:
[AllDay](https://github.com/dapperlabs/nfl-smart-contracts)
[PackNFT](https://github.com/flow-hydraulics/flow-pds/blob/main/cadence-contracts/PackNFT.cdc)

`AllDay` is the MomentNFT contract which defines Series, Sets, Plays, Editions, and MomentNFTs(made up of the former), and `PackNFT` is the on-chain pack contract.

Tested with the flow scripts provided as well as the `testGetNFTs.sh` script