### PR TITLE
Add Bitku

### DIFF
--- a/src/cadence/mainnet/getNFTIDs.cdc
+++ b/src/cadence/mainnet/getNFTIDs.cdc
@@ -36,6 +36,7 @@ import OneFootballCollectible from 0x6831760534292098
 import TheFabricantMysteryBox_FF1 from 0xa0cbe021821c0965
 import DieselNFT from 0x497153c597783bc3
 import MiamiNFT from 0x429a19abea586a3e
+import HaikuNFT from 0xf61e40c19db2a9e2
 
 pub fun main(ownerAddress: Address): {String: [UInt64]} {
     let owner = getAccount(ownerAddress)
@@ -202,5 +203,11 @@ pub fun main(ownerAddress: Address): {String: [UInt64]} {
     .borrow<&{MiamiNFT.MiamiCollectionPublic}>() {
         ids["MiamiNFT"] = col.getIDs()
     }
+
+    if let col = owner.getCapability(HaikuNFT.HaikuCollectionPublicPath)
+    .borrow<&{HaikuNFT.HaikuCollectionPublic}>() {
+        ids["Bitku"] = col.getIDs()
+    }
+
     return ids
 }

--- a/src/cadence/mainnet/getNFTs.cdc
+++ b/src/cadence/mainnet/getNFTs.cdc
@@ -36,6 +36,7 @@ import OneFootballCollectible from 0x6831760534292098
 import TheFabricantMysteryBox_FF1 from 0xa0cbe021821c0965
 import DieselNFT from 0x497153c597783bc3
 import MiamiNFT from 0x429a19abea586a3e
+import HaikuNFT from 0xf61e40c19db2a9e2
 
 pub struct NFTCollection {
     pub let owner: Address
@@ -164,6 +165,7 @@ pub fun main(ownerAddress: Address, ids: {String:[UInt64]}): [NFTData?] {
                 case "TheFabricantMysteryBox_FF1": d = getTheFabricantMysteryBox_FF1(owner: owner, id: id)
                 case "DieselNFT": d = getDieselNFT(owner: owner, id: id)
                 case "MiamiNFT": d = getMiamiNFT(owner: owner, id: id)
+                case "Bitku": d = getBitku(owner: owner, id: id)
                 default:
                     panic("adapter for NFT not found: ".concat(key))
             }
@@ -1484,6 +1486,39 @@ pub fun getMiamiNFT(owner: PublicAccount, id: UInt64): NFTData? {
         metadata: {            
             "creator": miamiData.creator,
             "season": miamiData.season
+        },
+    )
+}
+
+// https://flow-view-source.com/mainnet/account/0xf61e40c19db2a9e2/contract/HaikuNFT
+pub fun getBitku(owner: PublicAccount, id: UInt64): NFTData? {
+    let contract = NFTContract(
+        name: "Bitku",
+        address: 0xf61e40c19db2a9e2,
+        storage_path: "/storage/BitkuCollection",
+        public_path: "/public/BitkuCollection",
+        public_collection_name: "HaikuNFT.HaikuCollectionPublic",
+        external_domain: "bitku.art"
+    )
+
+    let col = owner.getCapability(HaikuNFT.HaikuCollectionPublicPath)
+        .borrow<&{HaikuNFT.HaikuCollectionPublic}>()
+    if col == nil { return nil }
+
+    let nft = col!.borrowHaiku(id: id)
+    if nft == nil { return nil }
+
+    return NFTData(
+        contract: contract,
+        id: nft!.id,
+        uuid: nil,
+        title: nil,
+        description: nft.text,
+        external_domain_view_url: nil,
+        token_uri: nil,
+        media: [],
+        metadata: {            
+            "text": nft.text
         },
     )
 }

--- a/src/cadence/mainnet/getNFTs.cdc
+++ b/src/cadence/mainnet/getNFTs.cdc
@@ -1567,7 +1567,7 @@ pub fun getBitku(owner: PublicAccount, id: UInt64): NFTData? {
         uuid: nil,
         title: nil,
         description: nft!.text,
-        external_domain_view_url: nil,
+        external_domain_view_url: "https://bitku.art/#".concat(owner.address.toString()).concat("/").concat(nft!.id.toString()),
         token_uri: nil,
         media: [],
         metadata: {            

--- a/src/cadence/mainnet/testGetNFTs.sh
+++ b/src/cadence/mainnet/testGetNFTs.sh
@@ -160,6 +160,11 @@ case $CONTRACT in
   echo "MiamiNFT"
     flow scripts execute getNFTs.cdc --args-json '[{ "type": "Address", "value": "0xe1d5954d03ccb02d" }, { "type": "Dictionary", "value": [{ "key": { "type": "String", "value": "MiamiNFT" }, "value": { "type": "Array", "value": [{ "type": "UInt64", "value": "1" }] } }] }]' --network mainnet
     ;;
+
+  Bitku)
+  echo "Bitku"
+    flow scripts execute getNFTs.cdc --args-json '[{ "type": "Address", "value": "0xf61e40c19db2a9e2" }, { "type": "Dictionary", "value": [{ "key": { "type": "String", "value": "Bitku" }, "value": { "type": "Array", "value": [{ "type": "UInt64", "value": "1" }] } }] }]' --network mainnet
+    ;;
   *)
     echo "Unknown contract"
     ;;

--- a/src/cadence/testnet/getNFTIDs.cdc
+++ b/src/cadence/testnet/getNFTIDs.cdc
@@ -32,6 +32,7 @@ import OneFootballCollectible from 0x01984fb4ca279d9a
 import TheFabricantMysteryBox_FF1 from 0x716db717f9240d8a
 import DieselNFT from 0x716db717f9240d8a
 import MiamiNFT from 0x716db717f9240d8a
+import HaikuNFT from 0x824f612f78d34250
 
 pub fun main(ownerAddress: Address): {String: [UInt64]} {
     let owner = getAccount(ownerAddress)
@@ -179,6 +180,11 @@ pub fun main(ownerAddress: Address): {String: [UInt64]} {
     if let col = owner.getCapability(MiamiNFT.CollectionPublicPath)
     .borrow<&{MiamiNFT.DieselCollectionPublic}>() {
         ids["MiamiNFT"] = col.getIDs()
+    }
+
+    if let col = owner.getCapability(HaikuNFT.HaikuCollectionPublicPath)
+    .borrow<&{HaikuNFT.HaikuCollectionPublic}>() {
+        ids["Bitku"] = col.getIDs()
     }
     
     return ids

--- a/src/cadence/testnet/getNFTs.cdc
+++ b/src/cadence/testnet/getNFTs.cdc
@@ -1385,7 +1385,7 @@ pub fun getBitku(owner: PublicAccount, id: UInt64): NFTData? {
         uuid: nil,
         title: nil,
         description: nft!.text,
-        external_domain_view_url: nil,
+        external_domain_view_url: "https://testnet.bitku.art/#".concat(owner.address.toString()).concat("/").concat(nft!.id.toString()),
         token_uri: nil,
         media: [],
         metadata: {            

--- a/src/cadence/testnet/getNFTs.cdc
+++ b/src/cadence/testnet/getNFTs.cdc
@@ -32,6 +32,7 @@ import OneFootballCollectible from 0x01984fb4ca279d9a
 import TheFabricantMysteryBox_FF1 from 0x716db717f9240d8a
 import DieselNFT from 0x716db717f9240d8a
 import MiamiNFT from 0x716db717f9240d8a
+import HaikuNFT from 0x824f612f78d34250
 
 pub struct NFTCollection {
     pub let owner: Address
@@ -1302,6 +1303,39 @@ pub fun getMiamiNFT(owner: PublicAccount, id: UInt64): NFTData? {
         metadata: {            
             "creator": miamiData.creator,
             "season": miamiData.season
+        },
+    )
+}
+
+// https://flow-view-source.com/testnet/account/0x824f612f78d34250/contract/HaikuNFT
+pub fun getBitku(owner: PublicAccount, id: UInt64): NFTData? {
+    let contract = NFTContract(
+        name: "Bitku",
+        address: 0x824f612f78d34250,
+        storage_path: "/storage/BitkuCollection",
+        public_path: "/public/BitkuCollection",
+        public_collection_name: "HaikuNFT.HaikuCollectionPublic",
+        external_domain: "testnet.bitku.art"
+    )
+
+    let col = owner.getCapability(HaikuNFT.HaikuCollectionPublicPath)
+        .borrow<&{HaikuNFT.HaikuCollectionPublic}>()
+    if col == nil { return nil }
+
+    let nft = col!.borrowHaiku(id: id)
+    if nft == nil { return nil }
+
+    return NFTData(
+        contract: contract,
+        id: nft!.id,
+        uuid: nil,
+        title: nil,
+        description: nft.text,
+        external_domain_view_url: nil,
+        token_uri: nil,
+        media: [],
+        metadata: {            
+            "text": nft.text
         },
     )
 }


### PR DESCRIPTION
This adds support for [Bitku](https://bitku.art/).

This NFT doesn't have any external media, just text stored on the blockchain.

I wasn't 100% sure how the `description` field is used by consumers of Alchemy, so I included the text of the NFT in both the `description` and the metadata. But I'm not sure if that's necessary. 