### PR TITLE
feat: add Gaia NFT data to metadata structure

### DIFF
--- a/src/cadence/mainnet/getNFTs.cdc
+++ b/src/cadence/mainnet/getNFTs.cdc
@@ -257,6 +257,11 @@ pub fun getGaia(owner: PublicAccount, id: UInt64): NFTData? {
 
     let metadata = Gaia.getTemplateMetaData(templateID: nft!.data.templateID)
 
+    // Populate Gaia NFT data attributes into the metadata
+    metadata!.insert(key: "setID", nft!.data.setID.toString())
+    metadata!.insert(key: "templateID", nft!.data.templateID.toString())
+    metadata!.insert(key: "mintNumber", nft!.data.mintNumber.toString())
+
     return NFTData(
         contract: contract,
         id: nft!.id,

--- a/src/cadence/testnet/getNFTs.cdc
+++ b/src/cadence/testnet/getNFTs.cdc
@@ -214,6 +214,11 @@ pub fun getGaia(owner: PublicAccount, id: UInt64): NFTData? {
 
     let metadata = Gaia.getTemplateMetaData(templateID: nft!.data.templateID)
 
+    // Populate Gaia NFT data attributes into the metadata
+    metadata!.insert(key: "setID", nft!.data.setID.toString())
+    metadata!.insert(key: "templateID", nft!.data.templateID.toString())
+    metadata!.insert(key: "mintNumber", nft!.data.mintNumber.toString())
+
     return NFTData(
         contract: contract,
         id: nft!.id,


### PR DESCRIPTION
The PR adds Gaia NFT data attributes to the metadata structure. We need to use such properties to group Ballerz NFTs.

See https://github.com/NFT-Genius/gaia-contracts/blob/main/contracts/Gaia.cdc#L373

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>