### PR TITLE
Fix metadata type for niftory

### DIFF
--- a/src/cadence/mainnet/getNFTs.cdc
+++ b/src/cadence/mainnet/getNFTs.cdc
@@ -381,7 +381,6 @@ pub fun getBeam(owner: PublicAccount, id: UInt64): NFTData? {
     if nft == nil { return nil }
 
     let metadata = Beam.getCollectibleItemMetaData(collectibleItemID: nft!.data.collectibleItemID)
-
     var mediaUrl: String? = nil
     if metadata!["mediaUrl"]  != nil {
         let metadataUrl = metadata!["mediaUrl"]!
@@ -391,6 +390,11 @@ pub fun getBeam(owner: PublicAccount, id: UInt64): NFTData? {
         } else {
             mediaUrl = "ipfs://".concat(metadataUrl)
         }
+    }
+
+    let outputMetadata: {String: String?} = {} 
+    for key in metadata!.keys {
+        outputMetadata[key] = metadata![key]
     }
 
     return NFTData(
@@ -403,7 +407,7 @@ pub fun getBeam(owner: PublicAccount, id: UInt64): NFTData? {
         token_uri: nil,
         media: [NFTMedia(uri: mediaUrl, mimetype: metadata!["mediaType"]),
             NFTMedia(uri: "ipfs://bafybeichtxzrocxo7ec5qybfxxlyod5bbymblitjwb2aalv2iyhe42pk4e/Frightclub.jpg", mimetype:"image/jpeg")],
-        metadata: metadata!,
+        metadata: outputMetadata,
     )
 }
 
@@ -469,6 +473,11 @@ pub fun getCrave(owner: PublicAccount, id: UInt64): NFTData? {
         }
     }
 
+    let outputMetadata: {String: String?} = {} 
+    for key in metadata!.keys {
+        outputMetadata[key] = metadata![key]
+    }
+
     return NFTData(
         contract: contract,
         id: nft!.id,
@@ -479,7 +488,7 @@ pub fun getCrave(owner: PublicAccount, id: UInt64): NFTData? {
         token_uri: nil,
         media: [NFTMedia(uri: mediaUrl, mimetype: metadata!["mediaType"]),
             NFTMedia(uri: "ipfs://bafybeiedrlfjykj4svmaka7jdxnhr3osigtudyrhitxsf7ska5ljeiwlxa/Crave Critics Banner.jpg", mimetype:"image/jpeg")],
-        metadata: metadata!,
+        metadata: outputMetadata,
     )
 }
 
@@ -735,6 +744,11 @@ pub fun getKOTD(owner: PublicAccount, id: UInt64): NFTData? {
         }
     }
 
+    let outputMetadata: {String: String?} = {} 
+    for key in metadata!.keys {
+        outputMetadata[key] = metadata![key]
+    }
+
     return NFTData(
         contract: contract,
         id: nft!.id,
@@ -745,7 +759,7 @@ pub fun getKOTD(owner: PublicAccount, id: UInt64): NFTData? {
         token_uri: nil,
         media: [NFTMedia(uri: mediaUrl, mimetype: metadata!["mediaType"]),
             NFTMedia(uri: "ipfs://bafybeidy62mofvdpzr5gujq57kcpm27pciqx33pahxbfuwgzea646k2nay/s1_poster.jpg", mimetype:"image/jpeg")],
-        metadata: metadata!,
+        metadata: outputMetadata!,
     )
 }
 

--- a/src/cadence/testnet/getNFTs.cdc
+++ b/src/cadence/testnet/getNFTs.cdc
@@ -298,6 +298,11 @@ pub fun getBeam(owner: PublicAccount, id: UInt64): NFTData? {
         }
     }
 
+    let outputMetadata: {String: String?} = {} 
+    for key in metadata!.keys {
+        outputMetadata[key] = metadata![key]
+    }
+
     return NFTData(
         contract: contract,
         id: nft!.id,
@@ -308,7 +313,7 @@ pub fun getBeam(owner: PublicAccount, id: UInt64): NFTData? {
         token_uri: nil,
         media: [NFTMedia(uri: mediaUrl, mimetype: metadata!["mediaType"]),
             NFTMedia(uri: "ipfs://bafybeichtxzrocxo7ec5qybfxxlyod5bbymblitjwb2aalv2iyhe42pk4e/Frightclub.jpg", mimetype:"image/jpeg")],
-        metadata: metadata!,
+        metadata: outputMetadata,
     )
 }
 
@@ -345,6 +350,12 @@ pub fun getCrave(owner: PublicAccount, id: UInt64): NFTData? {
             mediaUrl = ipfsPrefix.concat(metadataUrl)
         }
     }
+
+    let outputMetadata: {String: String?} = {} 
+    for key in metadata!.keys {
+        outputMetadata[key] = metadata![key]
+    }
+
     return NFTData(
         contract: contract,
         id: nft!.id,
@@ -355,7 +366,7 @@ pub fun getCrave(owner: PublicAccount, id: UInt64): NFTData? {
         token_uri: nil,
         media: [NFTMedia(uri: mediaUrl, mimetype: metadata!["mediaType"]),
             NFTMedia(uri: "ipfs://bafybeiedrlfjykj4svmaka7jdxnhr3osigtudyrhitxsf7ska5ljeiwlxa/Crave Critics Banner.jpg", mimetype:"image/jpeg")],
-        metadata: metadata!,
+        metadata: outputMetadata,
     )
 }
 // https://flow-view-source.com/testnet/account/0xb45e7992680a0f7f/contract/CricketMoments
@@ -598,6 +609,11 @@ pub fun getKOTD(owner: PublicAccount, id: UInt64): NFTData? {
         }
     }
 
+    let outputMetadata: {String: String?} = {} 
+    for key in metadata!.keys {
+        outputMetadata[key] = metadata![key]
+    }
+
     return NFTData(
         contract: contract,
         id: nft!.id,
@@ -608,7 +624,7 @@ pub fun getKOTD(owner: PublicAccount, id: UInt64): NFTData? {
         token_uri: nil,
         media: [NFTMedia(uri: mediaUrl, mimetype: metadata!["mediaType"]),
             NFTMedia(uri: "ipfs://bafybeidy62mofvdpzr5gujq57kcpm27pciqx33pahxbfuwgzea646k2nay/s1_poster.jpg", mimetype:"image/jpeg")],
-        metadata: metadata!,
+        metadata: outputMetadata,
     )
 }
 


### PR DESCRIPTION
This caught us by surprise... We would've appreciated some notice of breaking changes like this. Please merge this ASAP.

```
❌ Invalid argument: failed to execute script: failed to execute script at block (7ae942027cf384c956b3689fb7568609f22479fa4d6238a2403c46200602641b): [Error Code: 1101] cadence runtime error Execution failed:
error: mismatched types
   --> bd8b9a4b63e8355216542412f0b668f10db264661e82196e406d10b20b233d8f:406:18
    |
406 |         metadata: metadata,
    |                   ^^^^^^^^ expected `{String: String?}`, got `{String: String}?`
```